### PR TITLE
Fix to remove race conditions in vdc.go

### DIFF
--- a/vdc.go
+++ b/vdc.go
@@ -60,12 +60,14 @@ func (v *Vdc) Refresh() error {
 
 	// Empty struct before a new unmarshal, otherwise we end up with duplicate
 	// elements in slices.
-	v.Vdc = &types.Vdc{}
+	unmarshalledVdc := &types.Vdc{}
 
-	if err = decodeBody(resp, v.Vdc); err != nil {
-		return fmt.Errorf("error decoding Edge Gateway response: %s", err)
+	if err = decodeBody(resp, unmarshalledVdc); err != nil {
+		return fmt.Errorf("error decoding vdc response: %s", err)
 	}
 
+	v.Vdc = unmarshalledVdc
+	
 	// The request was successful
 	return nil
 }


### PR DESCRIPTION
Race conditions arises where, 1 thread is going through vdc.findVAppByName and accesses v.Vdc between line: v.Vdc = &types.Vdc{} and before decodeBody finishes.